### PR TITLE
Change libui-node description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A curated list of awesome packages and frameworks for implementing javascript ap
 * [Thrust](https://github.com/breach/thrust) - a Node.js and Chromium runtime to build cross platform desktop apps
 * [Electrino](https://github.com/pojala/electrino) - a desktop runtime for apps built on web technologies, using the system's own web browser engine (Mac OS only)
 * [Quark](https://github.com/jscherer92/Quark) - a desktop runtime for apps built on web technologies, using the system's own web browser engine (Windows only)
+* [vuido](https://github.com/mimecorg/vuido) - Native desktop applications using Vue.js.
 
 ## UI Frameworks
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A curated list of awesome packages and frameworks for implementing javascript ap
 ## UI Frameworks
 
 * [Yoga](https://github.com/facebook/yoga) - a layout engine which implements Flexbox to build cross-platform (node, browser asm, and standalone) apps
-* [libui-node](https://github.com/parro-it/libui-node) - a GUI library engine to build cross-platform (node, browser asm, and standalone) apps
+* [libui-node](https://github.com/parro-it/libui-node) - Node.js native desktop GUI framework to build cross-platform (Windows, macOS, Linux) apps.
 * [proton-native](https://github.com/kusti8/proton-native) a React environment to build cross platform native desktop apps
 * [Brig](https://github.com/BrigJS/brig) - a user interface toolkit based on Qt to build cross-platform apps
 * [trayballoon](https://github.com/sindresorhus/trayballoon) - a system tray balloon on Windows


### PR DESCRIPTION
What you mean exactly with "cross-platform node, browser asm, and standalone"?
node-libui does not work in browser, or without node. 

I changed the description of the package with s clearer (ATM) one.