### PR TITLE
Change HTML Frameworks to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ A curated list of awesome packages and frameworks for implementing javascript ap
 
 ## Contents
 
-* [HTML Frameworks](#html-frameworks)
+* [Web Frameworks](#web-frameworks)
 * [UI Frameworks](#ui-frameworks)
 * [System Tray](#system-tray)
 * [Packaging](#packaging)
 
-## HTML Frameworks
+## Web Frameworks
 
 * [Electron](https://github.com/electron/electron) - a Node.js and Chromium runtime to build cross platform desktop apps
 * [nw.js](https://github.com/nwjs/nw.js) - a Node.js and Chromium runtime to build cross platform desktop apps
 * [Thrust](https://github.com/breach/thrust) - a Node.js and Chromium runtime to build cross platform desktop apps
-* [Electrino](https://github.com/pojala/electrino) - a desktop runtime for apps built on web technologies, using the system's own web browser engine (Mac OS only)
-* [Quark](https://github.com/jscherer92/Quark) - a desktop runtime for apps built on web technologies, using the system's own web browser engine (Windows only)
-* [Quark Shell](https://github.com/HackPlan/quark-shell-mac) - create a desktop app with WebKit on MacOS 
+* [Electrino](https://github.com/pojala/electrino) - a runtime to build cross platform desktop apps using the system's own web browser engine (Mac OS only)
+* [Quark Shell](https://github.com/HackPlan/quark-shell-mac) - a runtime to build cross platform desktop apps using the system's own web browser engine (Mac OS only)
+* [Quark](https://github.com/jscherer92/Quark) - a runtime to build cross platform desktop apps using the system's own web browser engine (Windows only)
 
 ## UI Frameworks
 


### PR DESCRIPTION
This renames the HTML Frameworks section to Web Frameworks so its clear these are basically web browsers where you can use HTML, CSS, and JS.