### PR TITLE
Add caxa to the list of packaging solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of awesome packages and frameworks for implementing javascript ap
 * [launchui-packager](https://github.com/mimecorg/launchui-packager) - an API which packages GUI Node.js applications (Linux, Windows, macOS)
 * [nbin](https://github.com/cdr/nbin) - a cli which compiles your Node.js app into a single executable
 * [boxednode](https://github.com/mongodb-js/boxednode) - a cli (and API) which compiles your Node.js file into a single executable
+* [caxa](https://github.com/leafac/caxa) - a cli (and API) which compiles your Node.js app into a single executable
 
 ## License
 


### PR DESCRIPTION
If you don’t mind the shameless self-promotion 😃

caxa is different from the rest in having full support for every operating system, every Node.js version, and every npm dependency (including native modules), while still giving you fast build times (you don’t have to compile Node.js from source). More details [over at caxa’s README](https://github.com/leafac/caxa#prior-art).

Thank you 🙌